### PR TITLE
Fixed throwing an exception and class not found

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -2,6 +2,8 @@
 
 namespace Amostajo\LightweightMVC;
 
+use Exception;
+
 /**
  * MVC mini engine.
  *


### PR DESCRIPTION
When a controller is not found or an exception is thrown on the `Engine.php` class will fail to throw.
